### PR TITLE
fix exit codes for help and version

### DIFF
--- a/r2t.c
+++ b/r2t.c
@@ -333,12 +333,12 @@ int main(int argc, char *argv[])
 
 			case 'V':
 				version();
-				return 1;
+				return 0;
 
 			case 'h':
 			default:
 				usage();
-				return 1;
+				return 0;
 		}
 	}
 


### PR DESCRIPTION
command line options `-h` (help) and `-V` (version) resulted in an exit code 1 (error), not 0 (no error)