### PR TITLE
Check all urls before sleeping; only sleep for the given interval

### DIFF
--- a/r2t.c
+++ b/r2t.c
@@ -644,10 +644,6 @@ goto_next_url:
 			converter = 0;
 		}
 
-		cur_url++;
-		if (cur_url >= n_url)
-			cur_url = 0;
-
 		fflush(stdout);
 
 		if (one_shot)
@@ -656,7 +652,11 @@ goto_next_url:
 		if (verbose > 2)
 			printf("Sleeping...\n");
 
-		sleep((unsigned int)check_interval / (unsigned int) n_url);
+		cur_url++;
+		if (cur_url >= n_url) {
+			cur_url = 0;
+			sleep((unsigned int)check_interval);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
We should check all our feeds before sleeping (waiting for updates) instead of waiting in between each feed.

I'm not sure why we were dividing the interval by the number of urls here; the man page makes no mention of that so it would be surprising for users. Just check all the urls as fast as we can (i.e. no sleeping between each url), and when we've checked each url we sleep and repeat...

Also I was really tempted to write that if statement in the ultimate hackery `if (!(cur_url = (cur_url+1)%n_url)) sleep()` but reason prevailed (also don't @ me if what I just wrote is incorrect; I was just doing that on the fly -- which is probably another indicator to not do stuff like that in real code, because you can't tell if it's correct from a glance...)